### PR TITLE
Improve training speed by 30%~40%

### DIFF
--- a/cuda_rasterizer/auxiliary.h
+++ b/cuda_rasterizer/auxiliary.h
@@ -17,7 +17,6 @@
 
 #define BLOCK_SIZE (BLOCK_X * BLOCK_Y)
 #define NUM_WARPS (BLOCK_SIZE/32)
-#define FilterInvSquare 2.0
 
 #define TIGHTBBOX 0
 #define RENDER_AXUTILITY 1
@@ -37,6 +36,7 @@
 
 __device__ const float near_n = 0.2;
 __device__ const float far_n = 100.0;
+__device__ const float FilterInvSquare = 2.0f;
 
 // Spherical harmonics coefficients
 __device__ const float SH_C0 = 0.28209479177387814f;
@@ -180,15 +180,6 @@ __forceinline__ __device__ float2 minf2(float f, float2 a){return make_float2(mi
 __forceinline__ __device__ float3 maxf3(float f, float3 a){return make_float3(max(f, a.x), max(f, a.y), max(f, a.z));}
 
 __forceinline__ __device__ float2 maxf2(float f, float2 a){return make_float2(max(f, a.x), max(f, a.y));}
-
-
-__forceinline__ __device__ float3 crossProduct(float3 a, float3 b) {
-	float3 result;
-	result.x = a.y * b.z - a.z * b.y;
-    result.y = a.z * b.x - a.x * b.z;
-    result.z = a.x * b.y - a.y * b.x;
-    return result;
-}
 
 __forceinline__ __device__ bool in_frustum(int idx,
 	const float* orig_points,

--- a/cuda_rasterizer/auxiliary.h
+++ b/cuda_rasterizer/auxiliary.h
@@ -149,6 +149,37 @@ __forceinline__ __device__ float4 dnormvdv(float4 v, float4 dv)
 	return dnormvdv;
 }
 
+__forceinline__ __device__ float3 cross(float3 a, float3 b){return make_float3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);}
+
+__forceinline__ __device__ float3 operator*(float3 a, float3 b){return make_float3(a.x * b.x, a.y * b.y, a.z*b.z);}
+
+__forceinline__ __device__ float2 operator*(float2 a, float2 b){return make_float2(a.x * b.x, a.y * b.y);}
+
+__forceinline__ __device__ float3 operator*(float f, float3 a){return make_float3(f * a.x, f * a.y, f * a.z);}
+
+__forceinline__ __device__ float2 operator*(float f, float2 a){return make_float2(f * a.x, f * a.y);}
+
+__forceinline__ __device__ float3 operator-(float3 a, float3 b){return make_float3(a.x - b.x, a.y - b.y, a.z - b.z);}
+
+__forceinline__ __device__ float2 operator-(float2 a, float2 b){return make_float2(a.x - b.x, a.y - b.y);}
+
+__forceinline__ __device__ float sumf3(float3 a){return a.x + a.y + a.z;}
+
+__forceinline__ __device__ float sumf2(float2 a){return a.x + a.y;}
+
+__forceinline__ __device__ float3 sqrtf3(float3 a){return make_float3(sqrtf(a.x), sqrtf(a.y), sqrtf(a.z));}
+
+__forceinline__ __device__ float2 sqrtf2(float2 a){return make_float2(sqrtf(a.x), sqrtf(a.y));}
+
+__forceinline__ __device__ float3 minf3(float f, float3 a){return make_float3(min(f, a.x), min(f, a.y), min(f, a.z));}
+
+__forceinline__ __device__ float2 minf2(float f, float2 a){return make_float2(min(f, a.x), min(f, a.y));}
+
+__forceinline__ __device__ float3 maxf3(float f, float3 a){return make_float3(max(f, a.x), max(f, a.y), max(f, a.z));}
+
+__forceinline__ __device__ float2 maxf2(float f, float2 a){return make_float2(max(f, a.x), max(f, a.y));}
+
+
 __forceinline__ __device__ float3 crossProduct(float3 a, float3 b) {
 	float3 result;
 	result.x = a.y * b.z - a.z * b.y;

--- a/cuda_rasterizer/auxiliary.h
+++ b/cuda_rasterizer/auxiliary.h
@@ -18,7 +18,7 @@
 #define BLOCK_SIZE (BLOCK_X * BLOCK_Y)
 #define NUM_WARPS (BLOCK_SIZE/32)
 #define FilterSize 0.7071067811865476
-#define FilterInvSquare 1/(FilterSize*FilterSize)
+#define FilterInvSquare 2.0
 
 #define TIGHTBBOX 0
 #define RENDER_AXUTILITY 1

--- a/cuda_rasterizer/auxiliary.h
+++ b/cuda_rasterizer/auxiliary.h
@@ -17,7 +17,6 @@
 
 #define BLOCK_SIZE (BLOCK_X * BLOCK_Y)
 #define NUM_WARPS (BLOCK_SIZE/32)
-#define FilterSize 0.7071067811865476
 #define FilterInvSquare 2.0
 
 #define TIGHTBBOX 0
@@ -27,14 +26,17 @@
 #define NORMAL_OFFSET 2 
 #define MIDDEPTH_OFFSET 5
 #define DISTORTION_OFFSET 6
-#define MEDIAN_WEIGHT_OFFSET 7
+// #define MEDIAN_WEIGHT_OFFSET 7
 
 // distortion helper macros
 #define BACKFACE_CULL 1
 #define DUAL_VISIABLE 1
-#define NEAR_PLANE 0.2
-#define FAR_PLANE 100.0
+// #define NEAR_PLANE 0.2
+// #define FAR_PLANE 100.0
 #define DETACH_WEIGHT 0
+
+__device__ const float near_n = 0.2;
+__device__ const float far_n = 100.0;
 
 // Spherical harmonics coefficients
 __device__ const float SH_C0 = 0.28209479177387814f;
@@ -289,11 +291,11 @@ quat_to_rotmat_vjp(const glm::vec4 quat, const glm::mat3 v_R) {
 
 
 inline __device__ glm::mat3
-scale_to_mat(const float3 scale, const float glob_scale) {
+scale_to_mat(const glm::vec2 scale, const float glob_scale) {
 	glm::mat3 S = glm::mat3(1.f);
 	S[0][0] = glob_scale * scale.x;
 	S[1][1] = glob_scale * scale.y;
-	S[2][2] = glob_scale * scale.z;
+	// S[2][2] = glob_scale * scale.z;
 	return S;
 }
 

--- a/cuda_rasterizer/backward.cu
+++ b/cuda_rasterizer/backward.cu
@@ -203,8 +203,6 @@ renderCUDA(
 	float dL_dpixel[C];
 
 #if RENDER_AXUTILITY
-	const float far_n = FAR_PLANE;
-	const float near_n = NEAR_PLANE;
 	float dL_dreg;
 	float dL_ddepth;
 	float dL_daccum;
@@ -299,7 +297,7 @@ renderCUDA(
 			// compute intersection and depth
 			float rho = min(rho3d, rho2d);
 			float c_d = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z; 
-			if (c_d < NEAR_PLANE) continue;
+			if (c_d < near_n) continue;
 			float4 nor_o = collected_normal_opacity[j];
 			float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
 			float opa = nor_o.w;
@@ -441,191 +439,125 @@ renderCUDA(
 	}
 }
 
-inline __device__ void computeTransMat(
-	const glm::vec3 & p_world,
-	const glm::vec4 & quat,
-	const glm::vec2 & scale,
-	const float* viewmat,
-	const float* projmat,
-	const int W,
-	const int H,
-	const float* dL_dnormal3D,
-	const glm::mat3 & dL_dT,
-	glm::vec3 & dL_dmean3D,
-	glm::vec2 & dL_dscale,
-	glm::vec4 & dL_drot
-) {
-	const glm::mat4 world2ndc = glm::mat4(
-		projmat[0], projmat[4], projmat[8], projmat[12],
-		projmat[1], projmat[5], projmat[9], projmat[13],
-		projmat[2], projmat[6], projmat[10], projmat[14],
-		projmat[3], projmat[7], projmat[11], projmat[15]
-	);
 
-	const glm::mat3x4 ndc2pix = glm::mat3x4(
-		glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
-		glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
-		glm::vec4(0.0, 0.0, 0.0, 1.0)
-	);
-
-	const glm::mat3x4 P = world2ndc * ndc2pix;
-
-	glm::mat3x4 dL_dsplat = P * glm::transpose(dL_dT);
-
-	const glm::mat3 R = quat_to_rotmat(quat);
-
-	float multiplier = 1;
-
-#if  DUAL_VISIABLE
-	float3 normal = transformVec4x3({R[2].x, R[2].y, R[2].z}, viewmat);
-	multiplier = normal.z < 0 ? 1: -1;
-#endif
-
-	float3 dL_dtn = transformVec4x3Transpose({dL_dnormal3D[0],dL_dnormal3D[1],dL_dnormal3D[2]}, viewmat);
-	glm::mat3 dL_dRS = glm::mat3(
-		glm::vec3(dL_dsplat[0]),
-		glm::vec3(dL_dsplat[1]),
-		multiplier * glm::vec3(dL_dtn.x, dL_dtn.y, dL_dtn.z)
-	);
-
-	// propagate to scale and quat, mean
-	glm::mat3 dL_dR = glm::mat3(
-		dL_dRS[0] * glm::vec3(scale.x),
-		dL_dRS[1] * glm::vec3(scale.y),
-		dL_dRS[2]);
-
-	dL_dmean3D = glm::vec3(dL_dsplat[2]);
-	dL_drot = quat_to_rotmat_vjp(quat, dL_dR);
-	dL_dscale = glm::vec2(
-		(float)glm::dot(dL_dRS[0], R[0]),
-		(float)glm::dot(dL_dRS[1], R[1])
-	);
-}
-
-inline __device__ void computeAABB(
-	const float * transMat,
-	glm::vec3 & dL_dmean2D,
-	glm::mat3 & dL_dT) {
-
-	glm::mat4x3 T = glm::mat4x3(
-		transMat[0], transMat[1], transMat[2],
-		transMat[3], transMat[4], transMat[5],
-		transMat[6], transMat[7], transMat[8],
-		transMat[6], transMat[7], transMat[8]
-	);
-
-	float d = glm::dot(glm::vec3(1.0, 1.0, -1.0), T[3] * T[3]);
-	glm::vec3 f = glm::vec3(1.0, 1.0, -1.0) * (1.0f / d);
-
-	glm::vec3 p = glm::vec3(
-		glm::dot(f, T[0] * T[3]),
-		glm::dot(f, T[1] * T[3]), 
-		glm::dot(f, T[2] * T[3]));
-
-	dL_dT[0] += dL_dmean2D.x * f * T[3];
-	dL_dT[1] += dL_dmean2D.y * f * T[3];
-	dL_dT[2] += dL_dmean2D.x * f * T[0] + dL_dmean2D.y * f * T[1];
-	glm::vec3 dL_df = (dL_dmean2D.x * T[0] * T[3]) + (dL_dmean2D.y * T[1] * T[3]);
-	float dL_dd = glm::dot(dL_df, f) * (-1.0 / d);
-	glm::vec3 dd_dT3 = glm::vec3(1.0, 1.0, -1.0) * T[3] * 2.0f;
-	dL_dT[2] += dL_dd * dd_dT3;
-}
-
-
-__device__ void compute_radii_center(
+__device__ void compute_transmat_aabb(
 	int idx, 
-	const float3& p_orig, 
-	const glm::vec2 scale, 
-	const glm::vec4 rot, 
+	const float* Ts_precomp,
+	const float3* p_origs, 
+	const glm::vec2* scales, 
+	const glm::vec4* rots, 
 	const float* projmatrix, 
 	const float* viewmatrix, 
 	const int W, const int H, 
-	const float3* dL_dmean2D, 
-	const float3* dL_dnormal,
+	const float3* dL_dnormals,
+	const float3* dL_dmean2Ds, 
 	float* dL_dTs, 
 	glm::vec3* dL_dmeans, 
 	glm::vec2* dL_dscales,
 	 glm::vec4* dL_drots)
 {
-	glm::mat3 R = quat_to_rotmat(rot);
-	glm::mat3 S = scale_to_mat({scale.x, scale.y, 1.0f}, 1.0f);
-	glm::mat3 L = R * S;
+	glm::mat3 T;
+	float3 normal;
+	glm::mat3x4 P;
+	glm::mat3 R;
+	glm::mat3 S;
+	float3 p_orig;
+	glm::vec4 rot;
+	glm::vec2 scale;
+	
+	// Get transformation matrix of the Gaussian
+	if (Ts_precomp != nullptr) {
+		T = glm::mat3(
+			Ts_precomp[idx * 9 + 0], Ts_precomp[idx * 9 + 1], Ts_precomp[idx * 9 + 2],
+			Ts_precomp[idx * 9 + 3], Ts_precomp[idx * 9 + 4], Ts_precomp[idx * 9 + 5],
+			Ts_precomp[idx * 9 + 6], Ts_precomp[idx * 9 + 7], Ts_precomp[idx * 9 + 8]
+		);
+		normal = {0.0, 0.0, 0.0};
+	} else {
+		p_orig = p_origs[idx];
+		rot = rots[idx];
+		scale = scales[idx];
+		R = quat_to_rotmat(rot);
+		S = scale_to_mat(scale, 1.0f);
+		
+		glm::mat3 L = R * S;
+		glm::mat3x4 M = glm::mat3x4(
+			glm::vec4(L[0], 0.0),
+			glm::vec4(L[1], 0.0),
+			glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1)
+		);
 
-	// center of Gaussians in the camera coordinate
-	glm::mat3x4 M = glm::mat3x4(
-		glm::vec4(L[0], 0.0),
-		glm::vec4(L[1], 0.0),
-		glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1)
-	);
+		glm::mat4 world2ndc = glm::mat4(
+			projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
+			projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
+			projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
+			projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
+		);
 
-	glm::mat4 world2ndc = glm::mat4(
-		projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
-		projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
-		projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
-		projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
-	);
+		glm::mat3x4 ndc2pix = glm::mat3x4(
+			glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
+			glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
+			glm::vec4(0.0, 0.0, 0.0, 1.0)
+		);
 
-	glm::mat3x4 ndc2pix = glm::mat3x4(
-		glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
-		glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
-		glm::vec4(0.0, 0.0, 0.0, 1.0)
-	);
+		P = world2ndc * ndc2pix;
+		T = glm::transpose(M) * P;
+		normal = transformVec4x3({L[2].x, L[2].y, L[2].z}, viewmatrix);
+	}
 
-	glm::mat3x4 P = world2ndc * ndc2pix;
-	glm::mat3 T = glm::transpose(M) * P;
-	float3 normal = transformVec4x3({L[2].x, L[2].y, L[2].z}, viewmatrix);
-
-    const float3 T0 = {T[0][0], T[0][1], T[0][2]};
-    const float3 T1 = {T[1][0], T[1][1], T[1][2]};
-    const float3 T3 = {T[2][0], T[2][1], T[2][2]};
-	const float3 temp_point = {1.0f, 1.0f, -1.0f};
-    float distance = sumf3(T3 * T3 * temp_point);
-	const float f = 1 / (distance);
-
+	// Update gradients w.r.t. transformation matrix of the Gaussian
 	glm::mat3 dL_dT = glm::mat3(
 		dL_dTs[idx*9+0], dL_dTs[idx*9+1], dL_dTs[idx*9+2],
 		dL_dTs[idx*9+3], dL_dTs[idx*9+4], dL_dTs[idx*9+5],
 		dL_dTs[idx*9+6], dL_dTs[idx*9+7], dL_dTs[idx*9+8]
 	);
-
-	if(dL_dmean2D[idx].x != 0 || dL_dmean2D[idx].y != 0)
+	float3 dL_dmean2D = dL_dmean2Ds[idx];
+	if(dL_dmean2D.x != 0 || dL_dmean2D.y != 0)
 	{
-		const float dpx_dT00 = f * T3.x;
-		const float dpx_dT01 = f * T3.y;
-		const float dpx_dT02 = -f * T3.z;
-		const float dpy_dT10 = f * T3.x;
-		const float dpy_dT11 = f * T3.y;
-		const float dpy_dT12 = -f * T3.z;
-		const float dpx_dT30 = T0.x * (f - 2 * f * f * T3.x * T3.x);
-		const float dpx_dT31 = T0.y * (f - 2 * f * f * T3.y * T3.y);
-		const float dpx_dT32 = -T0.z * (f + 2 * f * f * T3.z * T3.z);
-		const float dpy_dT30 = T1.x * (f - 2 * f * f * T3.x * T3.x);
-		const float dpy_dT31 = T1.y * (f - 2 * f * f * T3.y * T3.y);
-		const float dpy_dT32 = -T1.z * (f + 2 * f * f * T3.z * T3.z);
+		const float distance = T[2].x * T[2].x + T[2].y * T[2].y - T[2].z * T[2].z;
+		const float f = 1 / (distance);
+		const float dpx_dT00 =  f * T[2].x;
+		const float dpx_dT01 =  f * T[2].y;
+		const float dpx_dT02 = -f * T[2].z;
+		const float dpy_dT10 =  f * T[2].x;
+		const float dpy_dT11 =  f * T[2].y;
+		const float dpy_dT12 = -f * T[2].z;
+		const float dpx_dT30 =  T[0].x * (f - 2 * f * f * T[2].x * T[2].x);
+		const float dpx_dT31 =  T[0].y * (f - 2 * f * f * T[2].y * T[2].y);
+		const float dpx_dT32 = -T[0].z * (f + 2 * f * f * T[2].z * T[2].z);
+		const float dpy_dT30 =  T[1].x * (f - 2 * f * f * T[2].x * T[2].x);
+		const float dpy_dT31 =  T[1].y * (f - 2 * f * f * T[2].y * T[2].y);
+		const float dpy_dT32 = -T[1].z * (f + 2 * f * f * T[2].z * T[2].z);
 
-		dL_dT[0].x += dL_dmean2D[idx].x * dpx_dT00;
-		dL_dT[0].y += dL_dmean2D[idx].x * dpx_dT01;
-		dL_dT[0].z += dL_dmean2D[idx].x * dpx_dT02;
-		dL_dT[1].x += dL_dmean2D[idx].y * dpy_dT10;
-		dL_dT[1].y += dL_dmean2D[idx].y * dpy_dT11;
-		dL_dT[1].z += dL_dmean2D[idx].y * dpy_dT12;
-		dL_dT[2].x += dL_dmean2D[idx].x * dpx_dT30 + dL_dmean2D[idx].y * dpy_dT30;
-		dL_dT[2].y += dL_dmean2D[idx].x * dpx_dT31 + dL_dmean2D[idx].y * dpy_dT31;
-		dL_dT[2].z += dL_dmean2D[idx].x * dpx_dT32 + dL_dmean2D[idx].y * dpy_dT32;
-		// dL_dT[idx*3+0].x += dL_dmean2D[idx].x * dpx_dT00;
-		// dL_dT[idx*3+0].y += dL_dmean2D[idx].x * dpx_dT01;
-		// dL_dT[idx*3+0].z += dL_dmean2D[idx].x * dpx_dT02;
-		// dL_dT[idx*3+1].x += dL_dmean2D[idx].y * dpy_dT10;
-		// dL_dT[idx*3+1].y += dL_dmean2D[idx].y * dpy_dT11;
-		// dL_dT[idx*3+1].z += dL_dmean2D[idx].y * dpy_dT12;
-		// dL_dT[idx*3+2].x += dL_dmean2D[idx].x * dpx_dT30 + dL_dmean2D[idx].y * dpy_dT30;
-		// dL_dT[idx*3+2].y += dL_dmean2D[idx].x * dpx_dT31 + dL_dmean2D[idx].y * dpy_dT31;
-		// dL_dT[idx*3+2].z += dL_dmean2D[idx].x * dpx_dT32 + dL_dmean2D[idx].y * dpy_dT32;
+		dL_dT[0].x += dL_dmean2D.x * dpx_dT00;
+		dL_dT[0].y += dL_dmean2D.x * dpx_dT01;
+		dL_dT[0].z += dL_dmean2D.x * dpx_dT02;
+		dL_dT[1].x += dL_dmean2D.y * dpy_dT10;
+		dL_dT[1].y += dL_dmean2D.y * dpy_dT11;
+		dL_dT[1].z += dL_dmean2D.y * dpy_dT12;
+		dL_dT[2].x += dL_dmean2D.x * dpx_dT30 + dL_dmean2D.y * dpy_dT30;
+		dL_dT[2].y += dL_dmean2D.x * dpx_dT31 + dL_dmean2D.y * dpy_dT31;
+		dL_dT[2].z += dL_dmean2D.x * dpx_dT32 + dL_dmean2D.y * dpy_dT32;
+
+		if (Ts_precomp != nullptr) {
+			dL_dTs[idx * 9 + 0] = dL_dT[0].x;
+			dL_dTs[idx * 9 + 1] = dL_dT[0].y;
+			dL_dTs[idx * 9 + 2] = dL_dT[0].z;
+			dL_dTs[idx * 9 + 3] = dL_dT[1].x;
+			dL_dTs[idx * 9 + 4] = dL_dT[1].y;
+			dL_dTs[idx * 9 + 5] = dL_dT[1].z;
+			dL_dTs[idx * 9 + 6] = dL_dT[2].x;
+			dL_dTs[idx * 9 + 7] = dL_dT[2].y;
+			dL_dTs[idx * 9 + 8] = dL_dT[2].z;
+			return;
+		}
 	}
 	
-	// write to the mean, scale, and rot
+	if (Ts_precomp != nullptr) return;
+
+	// Update gradients w.r.t. scaling, rotation, position of the Gaussian
 	glm::mat3x4 dL_dM = P * glm::transpose(dL_dT);
-	float3 dL_dtn = transformVec4x3Transpose(dL_dnormal[idx], viewmatrix);
+	float3 dL_dtn = transformVec4x3Transpose(dL_dnormals[idx], viewmatrix);
 #if DUAL_VISIABLE
 	float multiplier = normal.z < 0 ? 1: -1;
 	dL_dtn = multiplier * dL_dtn;
@@ -647,61 +579,7 @@ __device__ void compute_radii_center(
 		(float)glm::dot(dL_dRS[1], R[1])
 	);
 	dL_dmeans[idx] = glm::vec3(dL_dM[2]);
-	// (float4*)(dL_drots + idx)
-	// dL_drots[idx] = 
-	// glm::mat3 dL_dRS = glm::mat3(
-	// 	dL_dRS
-
-	// dL_dmeans[idx].x += dL_dT[3*idx+0].z * P[0][0] + dL_dT[3*idx+1].z * P[1][0] + dL_dT[3*idx+2].z * P[3][0];
-	// dL_dmeans[idx].y += dL_dT[3*idx+0].z * P[0][1] + dL_dT[3*idx+1].z * P[1][1] + dL_dT[3*idx+2].z * P[3][1];
-	// dL_dmeans[idx].z += dL_dT[3*idx+0].z * P[0][2] + dL_dT[3*idx+1].z * P[1][2] + dL_dT[3*idx+2].z * P[3][2];
-
-	// const float dL_dM00 = dL_dT[3*idx+0].x * P[0][0] + dL_dT[3*idx+1].x * P[1][0] + dL_dT[3*idx+2].x * P[3][0];
-	// const float dL_dM10 = dL_dT[3*idx+0].x * P[0][1] + dL_dT[3*idx+1].x * P[1][1] + dL_dT[3*idx+2].x * P[3][1];
-	// const float dL_dM20 = dL_dT[3*idx+0].x * P[0][2] + dL_dT[3*idx+1].x * P[1][2] + dL_dT[3*idx+2].x * P[3][2];
-
-	// const float dL_dM01 = dL_dT[3*idx+0].y * P[0][0] + dL_dT[3*idx+1].y * P[1][0] + dL_dT[3*idx+2].y * P[3][0];
-	// const float dL_dM11 = dL_dT[3*idx+0].y * P[0][1] + dL_dT[3*idx+1].y * P[1][1] + dL_dT[3*idx+2].y * P[3][1];
-	// const float dL_dM21 = dL_dT[3*idx+0].y * P[0][2] + dL_dT[3*idx+1].y * P[1][2] + dL_dT[3*idx+2].y * P[3][2];
-
-	// glm::mat3x2 dL_dM = glm::mat3x2{
-	// 	dL_dM00, dL_dM01,
-	// 	dL_dM10, dL_dM11,
-	// 	dL_dM20, dL_dM21
-	// };
-
-	// glm::mat3 Rt = glm::transpose(R);
-	// glm::mat2x3 dL_dMt = glm::transpose(dL_dM);
-
-	// Gradients of loss w.r.t. scale
-	// glm::vec2* dL_dscale = dL_dscales + idx;
-	// dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
-	// dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
-
-	// dL_dMt[0] *= s.x;
-	// dL_dMt[1] *= s.y;
-
-	// // Gradients of loss w.r.t. normalized quaternion
-	// glm::vec4 dL_dq;
-	// dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (- dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2]);
-	// dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2]) - 4 * x * (dL_dMt[1][1]);
-	// dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (- dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2]) - 4 * y * (dL_dMt[0][0]);
-	// dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
-
-	// const float dLcon_dx = dL_dnormal.x * 2.f * z - dL_dnormal.y * 2.f * r - dL_dnormal.z * 4.f * x;
-	// const float dLcon_dy = dL_dnormal.x * 2.f * r + dL_dnormal.y * 2.f * z - dL_dnormal.z * 4.f * y;
-	// const float dLcon_dz = dL_dnormal.x * 2.f * x + dL_dnormal.y * 2.f * y;
-	// const float dLcon_dr = dL_dnormal.x * 2.f * y - dL_dnormal.y * 2.f * x;
-	// dL_dq.x += dLcon_dr;
-	// dL_dq.y += dLcon_dx;
-	// dL_dq.z += dLcon_dy;
-	// dL_dq.w += dLcon_dz;
-
-	// Gradients of loss w.r.t. unnormalized quaternion
-	// float4* dL_drot = (float4*)(dL_drots + idx);
-	// *dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w};
-} 
-
+}
 
 template<int C>
 __global__ void preprocessCUDA(
@@ -737,46 +615,14 @@ __global__ void preprocessCUDA(
 
 	const int W = int(focal_x * tan_fovx * 2);
 	const int H = int(focal_y * tan_fovy * 2);
-	// const float* transMat = transMats + 9 * idx;
-	// const float3 * dL_dnormals = (float3*)dL_dnormal3Ds;
-
-	// const float3 p_world = { means3D[idx].x, means3D[idx].y, means3D[idx].z };
-	// const float3 p_view = transformPoint4x3(p_world, viewmatrix);
-	// glm::vec4 q = rotations[idx];
-	// float r = q.x;
-	// float x = q.y;
-	// float y = q.z;
-	// float z = q.w;
-	// float3 zaxis = {2.f * (x * z + r * y), 
-	// 				2.f * (y * z - r * x), 
-	// 				1.f - 2.f * (x * x + y * y)};
-	// float3 normal = transformVec4x3(zaxis, viewmatrix);
-	// float dL_dnx = 0.f;
-	// float dL_dny = 0.f;
-	// float dL_dnz = 0.f;
-	// if (sumf3(normal * p_view) > 0.f)
-	// {
-	// 	dL_dnx = -dL_dnormals[idx].x;
-	// 	dL_dny = -dL_dnormals[idx].y;
-	// 	dL_dnz = -dL_dnormals[idx].z;
-	// }
-	// else{
-	// 	dL_dnx = dL_dnormals[idx].x;
-	// 	dL_dny = dL_dnormals[idx].y;
-	// 	dL_dnz = dL_dnormals[idx].z;
-	// }
-
-	// const float3 dL_dnormal = {
-	// 	dL_dnx * viewmatrix[0] + dL_dny * viewmatrix[1] + dL_dnz * viewmatrix[2],
-	// 	dL_dnx * viewmatrix[4] + dL_dny * viewmatrix[5] + dL_dnz * viewmatrix[6],
-	// 	dL_dnx * viewmatrix[8] + dL_dny * viewmatrix[9] + dL_dnz * viewmatrix[10],
-	// };
-
-	compute_radii_center(idx, 
-		means3D[idx], scales[idx], rotations[idx], 
+	const float * Ts_precomp = (scales) ? nullptr : transMats;
+	compute_transmat_aabb(
+		idx, 
+		Ts_precomp,
+		means3D, scales, rotations, 
 		projmatrix, viewmatrix, W, H, 
-		dL_dmean2Ds, 
 		(float3*)dL_dnormal3Ds, 
+		dL_dmean2Ds,
 		(dL_dtransMats), 
 		dL_dmean3Ds, 
 		dL_dscales, 
@@ -786,9 +632,7 @@ __global__ void preprocessCUDA(
 	if (shs)
 		computeColorFromSH(idx, D, M, (glm::vec3*)means3D, *campos, shs, clamped, (glm::vec3*)dL_dcolors, (glm::vec3*)dL_dmean3Ds, (glm::vec3*)dL_dshs);
 	
-	// hack the gradient here
-	// dL_dmean2Ds[idx].x = 4.0f * dL_dmean3Ds[idx].x;
-	// dL_dmean2Ds[idx].y = 4.0f * dL_dmean3Ds[idx].y;
+	// hack the gradient here for densitification
 	float depth = transMats[idx * 9 + 8];
 	dL_dmean2Ds[idx].x = dL_dtransMats[idx * 9 + 2] * depth * 0.5 * float(W); // to ndc 
 	dL_dmean2Ds[idx].y = dL_dtransMats[idx * 9 + 5] * depth * 0.5 * float(H); // to ndc
@@ -818,25 +662,7 @@ void BACKWARD::preprocess(
 	glm::vec3* dL_dmean3Ds,
 	glm::vec2* dL_dscales,
 	glm::vec4* dL_drots)
-{
-	// Propagate gradients for the path of 2D conic matrix computation. 
-	// Somewhat long, thus it is its own kernel rather than being part of 
-	// "preprocess". When done, loss gradient w.r.t. 3D means has been
-	// modified and gradient w.r.t. 3D covariance matrix has been computed.	
-	// propagate gradients to transMat
-
-	// we do not use the center actually
-	// int W = focal_x * tan_fovx * 2;
-	// int H = focal_y * tan_fovy * 2;
-	// computeAABB << <(P + 255) / 256, 256 >> >(
-	// 	P,
-	// 	radii,
-	// 	W, H,
-	// 	transMats,
-	// 	dL_dmean2Ds,
-	// 	dL_dtransMats);
-	
-	// propagate gradients from transMat to mean3d, scale, rot, sh, color
+{	
 	preprocessCUDA<NUM_CHANNELS><< <(P + 255) / 256, 256 >> > (
 		P, D, M,
 		(float3*)means3D,

--- a/cuda_rasterizer/backward.cu
+++ b/cuda_rasterizer/backward.cu
@@ -339,7 +339,7 @@ renderCUDA(
 			float dL_dz = 0.0f;
 			float dL_dweight = 0;
 #if RENDER_AXUTILITY
-			const float m_d = (far_n * c_d - near_n * near_n) / ((far_n - near_n) * c_d);
+			const float m_d = far_n / (far_n - near_n) * (1 - near_n / c_d);
 			const float dmd_dd = (far_n * near_n) / ((far_n - near_n) * c_d * c_d);
 			if (contributor == median_contributor-1) {
 				dL_dz += dL_dmedian_depth;

--- a/cuda_rasterizer/backward.cu
+++ b/cuda_rasterizer/backward.cu
@@ -294,7 +294,7 @@ renderCUDA(
 			float2 s = {p.x / p.z, p.y / p.z};
 			float rho3d = (s.x * s.x + s.y * s.y); 
 			float2 d = {xy.x - pixf.x, xy.y - pixf.y};
-			float rho2d = 2.0 * (d.x * d.x + d.y * d.y); 
+			float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y); 
 
 			// compute intersection and depth
 			float rho = min(rho3d, rho2d);

--- a/cuda_rasterizer/backward.cu
+++ b/cuda_rasterizer/backward.cu
@@ -532,75 +532,61 @@ inline __device__ void computeAABB(
 }
 
 
-__device__ void compute_radii_center(int idx, const float3& p_orig, const glm::vec2 scale, const glm::vec4 rot, const float* projmatrix, const int W, const int H, const float3* dL_dmean2D, const float3 dL_dnormal,
-glm::vec3* dL_dmeans, float3* dL_dT,  glm::vec2* dL_dscales, glm::vec4* dL_drots)
+__device__ void compute_radii_center(
+	int idx, 
+	const float3& p_orig, 
+	const glm::vec2 scale, 
+	const glm::vec4 rot, 
+	const float* projmatrix, 
+	const float* viewmatrix, 
+	const int W, const int H, 
+	const float3* dL_dmean2D, 
+	const float3* dL_dnormal,
+	float* dL_dTs, 
+	glm::vec3* dL_dmeans, 
+	glm::vec2* dL_dscales,
+	 glm::vec4* dL_drots)
 {
-	const float far_n = FAR_PLANE;
-	const float near_n = NEAR_PLANE;
-	// Create scaling matrix
-	glm::mat3 S = glm::mat3(1.0f);
-	glm::vec2 s = scale;
-	S[0][0] = s.x;
-	S[1][1] = s.y;
-	// S[2][2] = s.z;
+	glm::mat3 R = quat_to_rotmat(rot);
+	glm::mat3 S = scale_to_mat({scale.x, scale.y, 1.0f}, 1.0f);
+	glm::mat3 L = R * S;
 
-	// Normalize quaternion to get valid rotation
-	glm::vec4 q = rot;
-	float r = q.x;
-	float x = q.y;
-	float y = q.z;
-	float z = q.w;
-
-	// Compute rotation matrix from quaternion
-	glm::mat3 R = glm::mat3(
-	    1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
-	    2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
-	    2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	// center of Gaussians in the camera coordinate
+	glm::mat3x4 M = glm::mat3x4(
+		glm::vec4(L[0], 0.0),
+		glm::vec4(L[1], 0.0),
+		glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1)
 	);
 
-	glm::mat3 L = S * R;
-
-    // center of Gaussians in the ndc coordinate
-	glm::vec4 p_world = glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1);
-    
-	glm::mat4x2 M = glm::mat4x2(
-		L[0][0], L[0][1],
-        L[1][0], L[1][1],
-		L[2][0], L[2][1],
-		0.0f   , 0.0f   
-	);
-
-	glm::mat4 World2Ndc = glm::mat4(
+	glm::mat4 world2ndc = glm::mat4(
 		projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
-        projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
-        projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
-        projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
+		projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
+		projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
+		projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
 	);
-	glm::mat4 Ndc2Pixel = glm::mat4(
-		float(W)/2,	0,		0,				float(W-1)/2,
-		0,		float(H)/2,	0,				float(H-1)/2,
-		0,		0,		far_n-near_n,	near_n,
-		0,		0,		0,				1 
-	);
-	glm::mat4 P = World2Ndc * Ndc2Pixel;
 
-	glm::vec4 p_pixel = p_world * P;
-    glm::mat4x2 uv_view = M * P;
-    glm::mat4x3 T = glm::mat4x3(
-        uv_view[0][0], uv_view[0][1], p_pixel.x,
-        uv_view[1][0], uv_view[1][1], p_pixel.y,
-		uv_view[2][0], uv_view[2][1], p_pixel.z,
-		uv_view[3][0], uv_view[3][1], p_pixel.w  
-    );
+	glm::mat3x4 ndc2pix = glm::mat3x4(
+		glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
+		glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
+		glm::vec4(0.0, 0.0, 0.0, 1.0)
+	);
+
+	glm::mat3x4 P = world2ndc * ndc2pix;
+	glm::mat3 T = glm::transpose(M) * P;
+	float3 normal = transformVec4x3({L[2].x, L[2].y, L[2].z}, viewmatrix);
 
     const float3 T0 = {T[0][0], T[0][1], T[0][2]};
     const float3 T1 = {T[1][0], T[1][1], T[1][2]};
-    const float3 T3 = {T[3][0], T[3][1], T[3][2]};
-
+    const float3 T3 = {T[2][0], T[2][1], T[2][2]};
 	const float3 temp_point = {1.0f, 1.0f, -1.0f};
     float distance = sumf3(T3 * T3 * temp_point);
+	const float f = 1 / (distance);
 
-	const float f = 1 / (distance + 0.0000001f);
+	glm::mat3 dL_dT = glm::mat3(
+		dL_dTs[idx*9+0], dL_dTs[idx*9+1], dL_dTs[idx*9+2],
+		dL_dTs[idx*9+3], dL_dTs[idx*9+4], dL_dTs[idx*9+5],
+		dL_dTs[idx*9+6], dL_dTs[idx*9+7], dL_dTs[idx*9+8]
+	);
 
 	if(dL_dmean2D[idx].x != 0 || dL_dmean2D[idx].y != 0)
 	{
@@ -617,65 +603,103 @@ glm::vec3* dL_dmeans, float3* dL_dT,  glm::vec2* dL_dscales, glm::vec4* dL_drots
 		const float dpy_dT31 = T1.y * (f - 2 * f * f * T3.y * T3.y);
 		const float dpy_dT32 = -T1.z * (f + 2 * f * f * T3.z * T3.z);
 
-		dL_dT[idx*3+0].x += dL_dmean2D[idx].x * dpx_dT00;
-		dL_dT[idx*3+0].y += dL_dmean2D[idx].x * dpx_dT01;
-		dL_dT[idx*3+0].z += dL_dmean2D[idx].x * dpx_dT02;
-		dL_dT[idx*3+1].x += dL_dmean2D[idx].y * dpy_dT10;
-		dL_dT[idx*3+1].y += dL_dmean2D[idx].y * dpy_dT11;
-		dL_dT[idx*3+1].z += dL_dmean2D[idx].y * dpy_dT12;
-		dL_dT[idx*3+2].x += dL_dmean2D[idx].x * dpx_dT30 + dL_dmean2D[idx].y * dpy_dT30;
-		dL_dT[idx*3+2].y += dL_dmean2D[idx].x * dpx_dT31 + dL_dmean2D[idx].y * dpy_dT31;
-		dL_dT[idx*3+2].z += dL_dmean2D[idx].x * dpx_dT32 + dL_dmean2D[idx].y * dpy_dT32;
+		dL_dT[0].x += dL_dmean2D[idx].x * dpx_dT00;
+		dL_dT[0].y += dL_dmean2D[idx].x * dpx_dT01;
+		dL_dT[0].z += dL_dmean2D[idx].x * dpx_dT02;
+		dL_dT[1].x += dL_dmean2D[idx].y * dpy_dT10;
+		dL_dT[1].y += dL_dmean2D[idx].y * dpy_dT11;
+		dL_dT[1].z += dL_dmean2D[idx].y * dpy_dT12;
+		dL_dT[2].x += dL_dmean2D[idx].x * dpx_dT30 + dL_dmean2D[idx].y * dpy_dT30;
+		dL_dT[2].y += dL_dmean2D[idx].x * dpx_dT31 + dL_dmean2D[idx].y * dpy_dT31;
+		dL_dT[2].z += dL_dmean2D[idx].x * dpx_dT32 + dL_dmean2D[idx].y * dpy_dT32;
+		// dL_dT[idx*3+0].x += dL_dmean2D[idx].x * dpx_dT00;
+		// dL_dT[idx*3+0].y += dL_dmean2D[idx].x * dpx_dT01;
+		// dL_dT[idx*3+0].z += dL_dmean2D[idx].x * dpx_dT02;
+		// dL_dT[idx*3+1].x += dL_dmean2D[idx].y * dpy_dT10;
+		// dL_dT[idx*3+1].y += dL_dmean2D[idx].y * dpy_dT11;
+		// dL_dT[idx*3+1].z += dL_dmean2D[idx].y * dpy_dT12;
+		// dL_dT[idx*3+2].x += dL_dmean2D[idx].x * dpx_dT30 + dL_dmean2D[idx].y * dpy_dT30;
+		// dL_dT[idx*3+2].y += dL_dmean2D[idx].x * dpx_dT31 + dL_dmean2D[idx].y * dpy_dT31;
+		// dL_dT[idx*3+2].z += dL_dmean2D[idx].x * dpx_dT32 + dL_dmean2D[idx].y * dpy_dT32;
 	}
 	
-	dL_dmeans[idx].x += dL_dT[3*idx+0].z * P[0][0] + dL_dT[3*idx+1].z * P[1][0] + dL_dT[3*idx+2].z * P[3][0];
-	dL_dmeans[idx].y += dL_dT[3*idx+0].z * P[0][1] + dL_dT[3*idx+1].z * P[1][1] + dL_dT[3*idx+2].z * P[3][1];
-	dL_dmeans[idx].z += dL_dT[3*idx+0].z * P[0][2] + dL_dT[3*idx+1].z * P[1][2] + dL_dT[3*idx+2].z * P[3][2];
+	// write to the mean, scale, and rot
+	glm::mat3x4 dL_dM = P * glm::transpose(dL_dT);
+	float3 dL_dtn = transformVec4x3Transpose(dL_dnormal[idx], viewmatrix);
+#if DUAL_VISIABLE
+	float multiplier = normal.z < 0 ? 1: -1;
+	dL_dtn = multiplier * dL_dtn;
+#endif
+	glm::mat3 dL_dRS = glm::mat3(
+		glm::vec3(dL_dM[0]),
+		glm::vec3(dL_dM[1]),
+		glm::vec3(dL_dtn.x, dL_dtn.y, dL_dtn.z)
+	);
 
-	const float dL_dM00 = dL_dT[3*idx+0].x * P[0][0] + dL_dT[3*idx+1].x * P[1][0] + dL_dT[3*idx+2].x * P[3][0];
-	const float dL_dM10 = dL_dT[3*idx+0].x * P[0][1] + dL_dT[3*idx+1].x * P[1][1] + dL_dT[3*idx+2].x * P[3][1];
-	const float dL_dM20 = dL_dT[3*idx+0].x * P[0][2] + dL_dT[3*idx+1].x * P[1][2] + dL_dT[3*idx+2].x * P[3][2];
+	glm::mat3 dL_dR = glm::mat3(
+		dL_dRS[0] * glm::vec3(scale.x),
+		dL_dRS[1] * glm::vec3(scale.y),
+		dL_dRS[2]);
+	
+	dL_drots[idx] = quat_to_rotmat_vjp(rot, dL_dR);
+	dL_dscales[idx] = glm::vec2(
+		(float)glm::dot(dL_dRS[0], R[0]),
+		(float)glm::dot(dL_dRS[1], R[1])
+	);
+	dL_dmeans[idx] = glm::vec3(dL_dM[2]);
+	// (float4*)(dL_drots + idx)
+	// dL_drots[idx] = 
+	// glm::mat3 dL_dRS = glm::mat3(
+	// 	dL_dRS
 
-	const float dL_dM01 = dL_dT[3*idx+0].y * P[0][0] + dL_dT[3*idx+1].y * P[1][0] + dL_dT[3*idx+2].y * P[3][0];
-	const float dL_dM11 = dL_dT[3*idx+0].y * P[0][1] + dL_dT[3*idx+1].y * P[1][1] + dL_dT[3*idx+2].y * P[3][1];
-	const float dL_dM21 = dL_dT[3*idx+0].y * P[0][2] + dL_dT[3*idx+1].y * P[1][2] + dL_dT[3*idx+2].y * P[3][2];
+	// dL_dmeans[idx].x += dL_dT[3*idx+0].z * P[0][0] + dL_dT[3*idx+1].z * P[1][0] + dL_dT[3*idx+2].z * P[3][0];
+	// dL_dmeans[idx].y += dL_dT[3*idx+0].z * P[0][1] + dL_dT[3*idx+1].z * P[1][1] + dL_dT[3*idx+2].z * P[3][1];
+	// dL_dmeans[idx].z += dL_dT[3*idx+0].z * P[0][2] + dL_dT[3*idx+1].z * P[1][2] + dL_dT[3*idx+2].z * P[3][2];
 
-	glm::mat3x2 dL_dM = glm::mat3x2{
-		dL_dM00, dL_dM01,
-		dL_dM10, dL_dM11,
-		dL_dM20, dL_dM21
-	};
+	// const float dL_dM00 = dL_dT[3*idx+0].x * P[0][0] + dL_dT[3*idx+1].x * P[1][0] + dL_dT[3*idx+2].x * P[3][0];
+	// const float dL_dM10 = dL_dT[3*idx+0].x * P[0][1] + dL_dT[3*idx+1].x * P[1][1] + dL_dT[3*idx+2].x * P[3][1];
+	// const float dL_dM20 = dL_dT[3*idx+0].x * P[0][2] + dL_dT[3*idx+1].x * P[1][2] + dL_dT[3*idx+2].x * P[3][2];
 
-	glm::mat3 Rt = glm::transpose(R);
-	glm::mat2x3 dL_dMt = glm::transpose(dL_dM);
+	// const float dL_dM01 = dL_dT[3*idx+0].y * P[0][0] + dL_dT[3*idx+1].y * P[1][0] + dL_dT[3*idx+2].y * P[3][0];
+	// const float dL_dM11 = dL_dT[3*idx+0].y * P[0][1] + dL_dT[3*idx+1].y * P[1][1] + dL_dT[3*idx+2].y * P[3][1];
+	// const float dL_dM21 = dL_dT[3*idx+0].y * P[0][2] + dL_dT[3*idx+1].y * P[1][2] + dL_dT[3*idx+2].y * P[3][2];
+
+	// glm::mat3x2 dL_dM = glm::mat3x2{
+	// 	dL_dM00, dL_dM01,
+	// 	dL_dM10, dL_dM11,
+	// 	dL_dM20, dL_dM21
+	// };
+
+	// glm::mat3 Rt = glm::transpose(R);
+	// glm::mat2x3 dL_dMt = glm::transpose(dL_dM);
 
 	// Gradients of loss w.r.t. scale
-	glm::vec2* dL_dscale = dL_dscales + idx;
-	dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
-	dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
+	// glm::vec2* dL_dscale = dL_dscales + idx;
+	// dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
+	// dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
 
-	dL_dMt[0] *= s.x;
-	dL_dMt[1] *= s.y;
+	// dL_dMt[0] *= s.x;
+	// dL_dMt[1] *= s.y;
 
-	// Gradients of loss w.r.t. normalized quaternion
-	glm::vec4 dL_dq;
-	dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (- dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2]);
-	dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2]) - 4 * x * (dL_dMt[1][1]);
-	dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (- dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2]) - 4 * y * (dL_dMt[0][0]);
-	dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
+	// // Gradients of loss w.r.t. normalized quaternion
+	// glm::vec4 dL_dq;
+	// dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (- dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2]);
+	// dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2]) - 4 * x * (dL_dMt[1][1]);
+	// dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (- dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2]) - 4 * y * (dL_dMt[0][0]);
+	// dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
 
-	const float dLcon_dx = dL_dnormal.x * 2.f * z - dL_dnormal.y * 2.f * r - dL_dnormal.z * 4.f * x;
-	const float dLcon_dy = dL_dnormal.x * 2.f * r + dL_dnormal.y * 2.f * z - dL_dnormal.z * 4.f * y;
-	const float dLcon_dz = dL_dnormal.x * 2.f * x + dL_dnormal.y * 2.f * y;
-	const float dLcon_dr = dL_dnormal.x * 2.f * y - dL_dnormal.y * 2.f * x;
-	dL_dq.x += dLcon_dr;
-	dL_dq.y += dLcon_dx;
-	dL_dq.z += dLcon_dy;
-	dL_dq.w += dLcon_dz;
+	// const float dLcon_dx = dL_dnormal.x * 2.f * z - dL_dnormal.y * 2.f * r - dL_dnormal.z * 4.f * x;
+	// const float dLcon_dy = dL_dnormal.x * 2.f * r + dL_dnormal.y * 2.f * z - dL_dnormal.z * 4.f * y;
+	// const float dLcon_dz = dL_dnormal.x * 2.f * x + dL_dnormal.y * 2.f * y;
+	// const float dLcon_dr = dL_dnormal.x * 2.f * y - dL_dnormal.y * 2.f * x;
+	// dL_dq.x += dLcon_dr;
+	// dL_dq.y += dLcon_dx;
+	// dL_dq.z += dLcon_dy;
+	// dL_dq.w += dLcon_dz;
 
 	// Gradients of loss w.r.t. unnormalized quaternion
-	float4* dL_drot = (float4*)(dL_drots + idx);
-	*dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w};
+	// float4* dL_drot = (float4*)(dL_drots + idx);
+	// *dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w};
 } 
 
 
@@ -713,42 +737,51 @@ __global__ void preprocessCUDA(
 
 	const int W = int(focal_x * tan_fovx * 2);
 	const int H = int(focal_y * tan_fovy * 2);
-	const float* transMat = transMats + 9 * idx;
-	const float3 * dL_dnormals = (float3*)dL_dnormal3Ds;
+	// const float* transMat = transMats + 9 * idx;
+	// const float3 * dL_dnormals = (float3*)dL_dnormal3Ds;
 
-	const float3 p_world = { means3D[idx].x, means3D[idx].y, means3D[idx].z };
-	const float3 p_view = transformPoint4x3(p_world, viewmatrix);
-	glm::vec4 q = rotations[idx];
-	float r = q.x;
-	float x = q.y;
-	float y = q.z;
-	float z = q.w;
-	float3 zaxis = {2.f * (x * z + r * y), 
-					2.f * (y * z - r * x), 
-					1.f - 2.f * (x * x + y * y)};
-	float3 normal = transformVec4x3(zaxis, viewmatrix);
-	float dL_dnx = 0.f;
-	float dL_dny = 0.f;
-	float dL_dnz = 0.f;
-	if (sumf3(normal * p_view) > 0.f)
-	{
-		dL_dnx = -dL_dnormals[idx].x;
-		dL_dny = -dL_dnormals[idx].y;
-		dL_dnz = -dL_dnormals[idx].z;
-	}
-	else{
-		dL_dnx = dL_dnormals[idx].x;
-		dL_dny = dL_dnormals[idx].y;
-		dL_dnz = dL_dnormals[idx].z;
-	}
+	// const float3 p_world = { means3D[idx].x, means3D[idx].y, means3D[idx].z };
+	// const float3 p_view = transformPoint4x3(p_world, viewmatrix);
+	// glm::vec4 q = rotations[idx];
+	// float r = q.x;
+	// float x = q.y;
+	// float y = q.z;
+	// float z = q.w;
+	// float3 zaxis = {2.f * (x * z + r * y), 
+	// 				2.f * (y * z - r * x), 
+	// 				1.f - 2.f * (x * x + y * y)};
+	// float3 normal = transformVec4x3(zaxis, viewmatrix);
+	// float dL_dnx = 0.f;
+	// float dL_dny = 0.f;
+	// float dL_dnz = 0.f;
+	// if (sumf3(normal * p_view) > 0.f)
+	// {
+	// 	dL_dnx = -dL_dnormals[idx].x;
+	// 	dL_dny = -dL_dnormals[idx].y;
+	// 	dL_dnz = -dL_dnormals[idx].z;
+	// }
+	// else{
+	// 	dL_dnx = dL_dnormals[idx].x;
+	// 	dL_dny = dL_dnormals[idx].y;
+	// 	dL_dnz = dL_dnormals[idx].z;
+	// }
 
-	const float3 dL_dnormal = {
-		dL_dnx * viewmatrix[0] + dL_dny * viewmatrix[1] + dL_dnz * viewmatrix[2],
-		dL_dnx * viewmatrix[4] + dL_dny * viewmatrix[5] + dL_dnz * viewmatrix[6],
-		dL_dnx * viewmatrix[8] + dL_dny * viewmatrix[9] + dL_dnz * viewmatrix[10],
-	};
+	// const float3 dL_dnormal = {
+	// 	dL_dnx * viewmatrix[0] + dL_dny * viewmatrix[1] + dL_dnz * viewmatrix[2],
+	// 	dL_dnx * viewmatrix[4] + dL_dny * viewmatrix[5] + dL_dnz * viewmatrix[6],
+	// 	dL_dnx * viewmatrix[8] + dL_dny * viewmatrix[9] + dL_dnz * viewmatrix[10],
+	// };
 
-	compute_radii_center(idx, means3D[idx], scales[idx], rotations[idx], projmatrix, W, H, dL_dmean2Ds, dL_dnormal, dL_dmean3Ds, (float3*)(dL_dtransMats), dL_dscales, dL_drots);
+	compute_radii_center(idx, 
+		means3D[idx], scales[idx], rotations[idx], 
+		projmatrix, viewmatrix, W, H, 
+		dL_dmean2Ds, 
+		(float3*)dL_dnormal3Ds, 
+		(dL_dtransMats), 
+		dL_dmean3Ds, 
+		dL_dscales, 
+		dL_drots
+	);
 
 	if (shs)
 		computeColorFromSH(idx, D, M, (glm::vec3*)means3D, *campos, shs, clamped, (glm::vec3*)dL_dcolors, (glm::vec3*)dL_dmean3Ds, (glm::vec3*)dL_dshs);
@@ -756,7 +789,7 @@ __global__ void preprocessCUDA(
 	// hack the gradient here
 	// dL_dmean2Ds[idx].x = 4.0f * dL_dmean3Ds[idx].x;
 	// dL_dmean2Ds[idx].y = 4.0f * dL_dmean3Ds[idx].y;
-	float depth = transMat[8];
+	float depth = transMats[idx * 9 + 8];
 	dL_dmean2Ds[idx].x = dL_dtransMats[idx * 9 + 2] * depth * 0.5 * float(W); // to ndc 
 	dL_dmean2Ds[idx].y = dL_dtransMats[idx * 9 + 5] * depth * 0.5 * float(H); // to ndc
 }

--- a/cuda_rasterizer/forward.cu
+++ b/cuda_rasterizer/forward.cu
@@ -145,112 +145,72 @@ __device__ bool computeAABB(const glm::mat3 & transMat, float2 & center, float2 
 	return true;
 }
 
-__device__ void compute_radii_center(
+__device__ glm::mat3 compute_radii_center(
 	const float3& p_orig,
 	const glm::vec2 scale,
 	const glm::vec4 rot,
 	const float* projmatrix,
 	const int W,
 	const int H, 
-	float3& rT0,
-	float3& rT1, 
-	float3& rT3, 
-	float3 &zaxis,
-	float2& p_pixel_xy,
-	float& radii
+	float3 &zaxis
 ) {
-		const float far_n = FAR_PLANE;
-		const float near_n = NEAR_PLANE;
-        // Create scaling matrix
-	    glm::mat3 S = glm::mat3(1.0f);
-	    S[0][0] = scale.x;
-	    S[1][1] = scale.y;
-	    // S[2][2] = scale.z;
 
-	    // Normalize quaternion to get valid rotation
-	    glm::vec4 q = rot;
-	    float r = q.x;
-	    float x = q.y;
-	    float y = q.z;
-	    float z = q.w;
+	glm::mat3 R = quat_to_rotmat(rot);
+	glm::mat3 S = scale_to_mat({scale.x, scale.y, 1.0f}, 1.0f);
+	glm::mat3 L = R * S;
+	zaxis = {L[2].x, L[2].y, L[2].z};
 
-	    // Compute rotation matrix from quaternion
-	    glm::mat3 R = glm::mat3(
-		    1.f - 2.f * (y * y + z * z), 	2.f * (x * y - r * z), 			2.f * (x * z + r * y),
-		    2.f * (x * y + r * z), 			1.f - 2.f * (x * x + z * z), 	2.f * (y * z - r * x),
-		    2.f * (x * z - r * y), 			2.f * (y * z + r * x), 			1.f - 2.f * (x * x + y * y)
-	    );
+	// center of Gaussians in the camera coordinate
+	glm::mat3x4 splat2world = glm::mat3x4(
+		glm::vec4(L[0], 0.0),
+		glm::vec4(L[1], 0.0),
+		glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1)
+	);
 
-		zaxis = {2.f * (x * z + r * y), 
-				 2.f * (y * z - r * x), 
-				 1.f - 2.f * (x * x + y * y)};
+	glm::mat4 world2ndc = glm::mat4(
+		projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
+		projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
+		projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
+		projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
+	);
 
-	    glm::mat3 L = S * R;
+	glm::mat3x4 ndc2pix = glm::mat3x4(
+		glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
+		glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
+		glm::vec4(0.0, 0.0, 0.0, 1.0)
+	);
 
-        // center of Gaussians in the camera coordinate
-        glm::vec4 p_world = glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1);
+	glm::mat3 T = glm::transpose(splat2world) * world2ndc * ndc2pix;
+	return T;
+}
 
-		glm::mat4x2 M = glm::mat4x2(
-			L[0][0], L[0][1], 
-            L[1][0], L[1][1], 
-			L[2][0], L[2][1], 
-			0.0f   , 0.0f    
-		);
+__device__ bool compute_aabb(
+	glm::mat3 T, 
+	float2& point_image,
+	float2 & extent
+) {
+	float3 T0 = {T[0][0], T[0][1], T[0][2]};
+	float3 T1 = {T[1][0], T[1][1], T[1][2]};
+	float3 T3 = {T[2][0], T[2][1], T[2][2]};
 
-		glm::mat4 World2Ndc = glm::mat4(
-			projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
-            projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
-            projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
-            projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
-		);
-		glm::mat4 Ndc2Pixel = glm::mat4(
-			float(W)/2,	0,		0,				float(W-1)/2,
-			0,		float(H)/2,	0,				float(H-1)/2,
-			0,		0,		far_n-near_n,	near_n,
-			0,		0,		0,				1 
-		);
-		glm::mat4 P = World2Ndc * Ndc2Pixel;
+	// Compute AABB
+	float3 temp_point = {1.0f, 1.0f, -1.0f};
+	float distance = sumf3(T3 * T3 * temp_point);
+	float3 f = (1 / distance) * temp_point;
+	if (distance == 0.0) return false;
 
-		glm::vec4 p_pixel = p_world * P;
-        glm::mat4x2 uv_view = M * P;
-        glm::mat4x3 T = glm::mat4x3(
-            uv_view[0][0], uv_view[0][1], p_pixel.x,
-            uv_view[1][0], uv_view[1][1], p_pixel.y,
-			uv_view[2][0], uv_view[2][1], p_pixel.z,
-			uv_view[3][0], uv_view[3][1], p_pixel.w  
-        );
-
-        float3 T0 = {T[0][0], T[0][1], T[0][2]};
-        float3 T1 = {T[1][0], T[1][1], T[1][2]};
-        float3 T2 = {T[2][0], T[2][1], T[2][2]};
-        float3 T3 = {T[3][0], T[3][1], T[3][2]};
-
-		// Compute AABB
-        float3 temp_point = {1.0f, 1.0f, -1.0f};
-        float distance = sumf3(T3 * T3 * temp_point);
-		
-        float3 f = {
-			1 / (distance + 0.0000001f), 
-			1 / (distance + 0.0000001f), 
-			-1 / (distance + 0.0000001f)
-		};
-        float2 point_image = {
-            sumf3(f * T0 * T3),
-            sumf3(f * T1 * T3)
-        };  
-		
-        float2 temp = {
-            sumf3(f * T0 * T0),
-            sumf3(f * T1 * T1)
-		};
-        float2 half_extend = point_image * point_image - temp;
-        float2 radii2 = sqrtf2(maxf2(1e-4, half_extend));
-		
-		radii = 3.0f * ceil(max(radii2.x, radii2.y));
-		p_pixel_xy = {point_image.x, point_image.y};
-		rT0 = T0;
-		rT1 = T1;
-		rT3 = T3;
+	point_image = {
+		sumf3(f * T0 * T3),
+		sumf3(f * T1 * T3)
+	};  
+	
+	float2 temp = {
+		sumf3(f * T0 * T0),
+		sumf3(f * T1 * T1)
+	};
+	float2 half_extend = point_image * point_image - temp;
+	extent = sqrtf2(maxf2(1e-4, half_extend));
+	return true;
 }
 
 // Perform initial steps for each Gaussian prior to rasterization.
@@ -295,20 +255,23 @@ __global__ void preprocessCUDA(int P, int D, int M,
 	if (!in_frustum(idx, orig_points, viewmatrix, projmatrix, prefiltered, p_view))
 		return;
 	
-	// const float* transMat;
-	// float3 normal;
-	float3 p_world = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
-	float radius;
-	float2 point_image;
-	float3 rT0, rT1, rT3;
-	float3 zaxis;
-	compute_radii_center(p_world, scales[idx], rotations[idx], projmatrix, W, H, rT0, rT1, rT3, zaxis, point_image, radius);
-	float3 normal = transformVec4x3(zaxis, viewmatrix);
-	if (sumf3(normal * p_view) > 0.f)
-		normal = {-normal.x, -normal.y, -normal.z};
-	
+	// compute transformation matrix
+	float3 *T_ptr = (float3*)transMats;
+	glm::mat3 T;
+	float3 normal;
+	{
+		float3 zaxis;
+		float3 p_world = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+		T = compute_radii_center(p_world, scales[idx], rotations[idx], projmatrix, W, H, zaxis);
+		T_ptr[idx * 3 + 0] = {T[0][0], T[0][1], T[0][2]};
+		T_ptr[idx * 3 + 1] = {T[1][0], T[1][1], T[1][2]};
+		T_ptr[idx * 3 + 2] = {T[2][0], T[2][1], T[2][2]};
+		normal = transformVec4x3(zaxis, viewmatrix);
+		if (sumf3(normal * p_view) > 0.f)
+			normal = {-normal.x, -normal.y, -normal.z};
+	}
 
-	// add the bounding of countour
+// add the bounding of countour
 // #if TIGHTBBOX // no use in the paper, but it indeed help speeds.
 // 	// the effective extent is now depended on the opacity of gaussian.
 // 	float truncated_R = sqrtf(max(9.f + 2.f * logf(opacities[idx]), 0.000001));
@@ -316,6 +279,16 @@ __global__ void preprocessCUDA(int P, int D, int M,
 // 	float truncated_R = 2.f;
 // #endif
 // 	float radius = ceil(truncated_R * max(max(extent.x, extent.y), FilterSize));
+
+	// compute center and radius
+	float2 point_image;
+	float radius;
+	{
+		float2 extent;
+		bool ok = compute_aabb(T, point_image, extent);
+		if (!ok) return;
+		radius = 3.0f * ceil(max(extent.x, extent.y));
+	}
 
 	uint2 rect_min, rect_max;
 	getRect(point_image, radius, rect_min, rect_max, grid);
@@ -329,11 +302,6 @@ __global__ void preprocessCUDA(int P, int D, int M,
 		rgb[idx * C + 1] = result.y;
 		rgb[idx * C + 2] = result.z;
 	}
-
-	float3 *T_ptr = (float3*)transMats;
-	T_ptr[idx * 3 + 0] = rT0;
-	T_ptr[idx * 3 + 1] = rT1;
-	T_ptr[idx * 3 + 2] = rT3;
 
 	depths[idx] = p_view.z;
 	radii[idx] = (int)radius;
@@ -452,7 +420,7 @@ renderCUDA(
 			float2 s = {p.x / p.z, p.y / p.z};
 			float rho3d = (s.x * s.x + s.y * s.y); 
 			float2 d = {xy.x - pixf.x, xy.y - pixf.y};
-			float rho2d = 2.0 * (d.x * d.x + d.y * d.y); 
+			float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y); 
 
 			// compute intersection and depth
 			float rho = min(rho3d, rho2d);

--- a/cuda_rasterizer/forward.cu
+++ b/cuda_rasterizer/forward.cu
@@ -379,7 +379,7 @@ renderCUDA(
 			float w = alpha * T;
 #if RENDER_AXUTILITY
 			// Render depth distortion map
-			// render depth
+			// Efficient implementation of distortion loss, see 2DGS' paper appendix.
 			float A = 1-T;
 			float m = far_n / (far_n - near_n) * (1 - near_n / depth);
 			distortion += (m * m * A + M2 - 2 * m * M1) * w;
@@ -398,7 +398,7 @@ renderCUDA(
 
 			// Eq. (3) from 3D Gaussian splatting paper.
 			for (int ch = 0; ch < CHANNELS; ch++)
-				C[ch] += features[collected_id[j] * CHANNELS + ch] * alpha * T;
+				C[ch] += features[collected_id[j] * CHANNELS + ch] * w;
 			T = test_T;
 
 			// Keep track of last range entry to update this

--- a/rasterize_points.cu
+++ b/rasterize_points.cu
@@ -83,7 +83,7 @@ RasterizeGaussiansCUDA(
   auto float_opts = means3D.options().dtype(torch::kFloat32);
 
   torch::Tensor out_color = torch::full({NUM_CHANNELS, H, W}, 0.0, float_opts);
-  torch::Tensor out_others = torch::full({3+3+2, H, W}, 0.0, float_opts);
+  torch::Tensor out_others = torch::full({3+3+1, H, W}, 0.0, float_opts);
   torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
   
   torch::Device device(torch::kCUDA);


### PR DESCRIPTION
Fusing some operators, lead to better training speed. Note that all hyper-parameters and setting are kept the same.

Test on the whole DTU dataset with one RTX3090.

|  | CD | Time |
| :-----| :----: | :----: | 
| 3DGS | 1.96 | 11.2min |
| 2DGS (paper) | 0.80 | 18.2min |
| **2DGS (This)** | **0.79** | **10.9min** |

Tested on a NeRF Synthetic Chair with one RTX3090

| EXP              | PSNR | Time |
| :---------------- | :------: | ----: |
| 2DGS (old)           |   35.35   | 12 min |
| 2DGS (old T_precomp)   |  35.35   | 21 min |
| **2DGS (This)** | **35.20** | **7 min 46s** |
| **2DGS (This T_precomp)** | **35.35** | **14min 50s** |


Tested on MipNeRF360 garden scene
| EXP              | PSNR | Time |
| :---------------- | :------: | ----: |
| 2DGS (old)           |  26.89   | 50 min 56s |
| **2DGS  (This)**           |  **26.84**  | **31 min 02s** |

